### PR TITLE
sale_configurator_option: hide by default type of qty in sale form

### DIFF
--- a/sale_configurator_option/views/sale_view.xml
+++ b/sale_configurator_option/views/sale_view.xml
@@ -53,7 +53,7 @@
                 position="before"
             >
                 <field name="option_unit_qty" string="Qty" />
-                <field name="option_qty_type" string="Qty type" invisible="0" />
+                <field name="option_qty_type" string="Qty type" optional="hide" />
             </xpath>
             <xpath
                 expr="//field[@name='option_ids']/tree/field[@name='product_uom_qty']"


### PR DESCRIPTION
Because, in most of the cases, the product is well configured and this
setting is not changed on child lines.