### PR TITLE
[FIX] sale_configurator_base: Fix duplicate string 'Customer' on sale.order.line

### DIFF
--- a/sale_configurator_base/models/sale.py
+++ b/sale_configurator_base/models/sale.py
@@ -126,7 +126,7 @@ class SaleOrderLine(models.Model):
     # but we want to make the view as much compatible between child view
     # wo want a native view do parent.partner_id we want to have the same behaviour
     # with the child line (but in that case the parent is a sale order line
-    partner_id = fields.Many2one(related="order_id.partner_id", string="Customer")
+    partner_id = fields.Many2one(related="order_id.partner_id", string="Order Customer")
 
     is_configurable = fields.Boolean(
         "Line is a configurable Product ?",


### PR DESCRIPTION
Nothing important, just being easier on sentry since `sale_order_line.partner_id` has already 'Customer' as string leading to warnings