### PR TITLE
FIX: display note and section properly if a parent line exists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/sale_configurator_base/templates/sale_report_templates.xml
+++ b/sale_configurator_base/templates/sale_report_templates.xml
@@ -20,10 +20,7 @@
             </t>
         </xpath>
         <!-- change the way section and notes are displayed in children lines -->
-        <xpath
-            expr="//td[@name='td_note_line']/span"
-            position="replace"
-        >
+        <xpath expr="//td[@name='td_note_line']/span" position="replace">
             <t t-if="line.parent_id">
                 <span
                     t-field="line.name"
@@ -34,10 +31,7 @@
                 <span t-field="line.name" />
             </t>
         </xpath>
-        <xpath
-            expr="//td[@name='td_section_line']/span"
-            position="replace"
-        >
+        <xpath expr="//td[@name='td_section_line']/span" position="replace">
             <t t-if="line.parent_id">
                 <span
                     t-field="line.name"

--- a/sale_configurator_base/templates/sale_report_templates.xml
+++ b/sale_configurator_base/templates/sale_report_templates.xml
@@ -19,6 +19,35 @@
                 <span t-field="line.name" />
             </t>
         </xpath>
+        <!-- change the way section and notes are displayed in children lines -->
+        <xpath
+            expr="//td[@name='td_note_line']/span"
+            position="replace"
+        >
+            <t t-if="line.parent_id">
+                <span
+                    t-field="line.name"
+                    style="padding-left:50px;font-style:italic;"
+                />
+            </t>
+            <t t-if="not line.parent_id">
+                <span t-field="line.name" />
+            </t>
+        </xpath>
+        <xpath
+            expr="//td[@name='td_section_line']/span"
+            position="replace"
+        >
+            <t t-if="line.parent_id">
+                <span
+                    t-field="line.name"
+                    style="padding-left:50px;font-style:italic;"
+                />
+            </t>
+            <t t-if="not line.parent_id">
+                <span t-field="line.name" />
+            </t>
+        </xpath>
 
         <!--
         We need to distinguish configurable mode from "classic" Odoo invoice


### PR DESCRIPTION
thanks to #26, we can add notes and sections in options lines. 
This PR allows the report (print) document to take care of this and put a margin-left to visually identify what's inside a configurable product
![iScreen Shoter - Google Chrome - 230512101548](https://github.com/akretion/sale-configurator/assets/8102312/36c7cd75-5aec-48ae-9723-22d318e241dc)
