### PR TITLE
[14.0] [FIX] sale_configurator_base: Check editable tree state

### DIFF
--- a/sale_configurator_base/models/sale.py
+++ b/sale_configurator_base/models/sale.py
@@ -64,9 +64,11 @@ class SaleOrder(models.Model):
         )
         if view_type == "form" and not self._context.get("force_original_sale_form"):
             doc = etree.XML(res["arch"])
+            tree = doc.xpath("//field[@name='order_line']/tree")
+            editable = tree and tree[0].get("editable")
             for field in doc.xpath("//field[@name='order_line']/tree/field"):
                 fname = field.get("name")
-                if fname != "sequence":
+                if fname != "sequence" and editable:
                     if not self.env["sale.order.line"]._fields[fname].readonly:
                         update_attrs(
                             field,


### PR DESCRIPTION
Prevent loss of modifications in sale order lines in case of editable="" tree. 

This can happen if some module like product_contract changes this attribute. 

In this case the field should not be readonly otherwise the UI will accept changes in the form but won't effectively save them.